### PR TITLE
Resolve unknown dependency in AuthModule

### DIFF
--- a/api-gateway/src/auth/strategies/jwt.strategy.ts
+++ b/api-gateway/src/auth/strategies/jwt.strategy.ts
@@ -3,17 +3,17 @@ import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
 import { JwtAuthService, JwtPayload } from '../jwt.service';
-import { User } from '../entities/user.entity';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { User, UserDocument } from '../schemas/user.schema';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
   constructor(
     private readonly configService: ConfigService,
     private readonly jwtAuthService: JwtAuthService,
-    @InjectRepository(User)
-    private readonly userRepository: Repository<User>,
+    @InjectModel(User.name)
+    private readonly userModel: Model<UserDocument>,
   ) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
@@ -23,9 +23,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(payload: JwtPayload): Promise<User> {
-    const user = await this.userRepository.findOne({
-      where: { id: payload.sub },
-    });
+    const user = await this.userModel.findById(payload.sub).exec();
 
     if (!user || !user.isActive) {
       throw new UnauthorizedException('Invalid token');


### PR DESCRIPTION
Update `JwtStrategy` to use Mongoose for user lookup, resolving a dependency injection error caused by a mismatch with the `AuthModule`'s Mongoose configuration.

The `JwtStrategy` was attempting to inject a TypeORM `UserRepository` while the `AuthModule` was configured for Mongoose, leading to an `UnknownDependenciesException`. This change aligns the strategy with the application's MongoDB/Mongoose setup.

---
<a href="https://cursor.com/background-agent?bcId=bc-cafa8f99-7d13-4bfc-9e3e-f901060e930b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cafa8f99-7d13-4bfc-9e3e-f901060e930b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

